### PR TITLE
Fix pub dev linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ This project is port from [Javascript eWelink API](https://ewelink-api.vercel.ap
 
 This package is a pure `Dart` package, and should work in any platform that Dart of Flutter supports.
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
 ```dart
 import 'package:dart_ewelink_api/dart_ewelink_api.dart';
 


### PR DESCRIPTION
Pub dev is not allowing to publish because of README. There was an a piece of text left from the template and pub dev recognizes as an unwritten readme.

Uploading... (1.7s)
`README.md` contains a generic text fragment coming from package templates (`TODO: Include short and useful examples for package users`). Please follow the guides to write great package pages: https://dart.dev/guides/libraries/writing-package-pages